### PR TITLE
shift base level view left by 0.5 so they sit inside rendered nodes

### DIFF
--- a/app/src/viewer_1d/render.rs
+++ b/app/src/viewer_1d/render.rs
@@ -51,7 +51,7 @@ pub fn sequence_shapes_in_slot(
                 (view_start.checked_sub(node_start)).unwrap_or(0) as usize;
 
             for (ix, &base) in seq.iter().skip(to_skip).enumerate() {
-                let x = xl + bp_width / 2.0 + bp_width * ix as f32;
+                let x = xl + bp_width / 2.0 + bp_width * (ix as f32 - 0.5);
 
                 let c = base as char;
 


### PR DESCRIPTION
Make base characters show up directly in the middle of nodes.

This makes it easier to read small variation.

Before vs. after.

![Screenshot from 2023-08-12 12-49-27](https://github.com/chfi/waragraph/assets/145425/a41e1eac-3d0a-42e0-b5ba-b424f23606f8)

![image](https://github.com/chfi/waragraph/assets/145425/74d901e2-764e-4082-88f9-6acd9b194b78)
